### PR TITLE
Escape XML characters in strings

### DIFF
--- a/json-viewer.js
+++ b/json-viewer.js
@@ -25,6 +25,20 @@
                                 return value;
                             }
 
+                            if (angular.isString(value)) {
+                                value = value.replace(/[<>"'&]/g,
+                                    function(char) {
+                                        switch (char) {
+                                            case '<': return '&lt;';
+                                            case '>': return '&gt;';
+                                            case '"': return '&quot;';
+                                            case "'": return '&apos;';
+                                            case '&': return '&amp;';
+                                        }
+                                        return char;
+                                    });
+                            }
+
                             return '<' + type.toUpperCase() + '>' + value +'</'+type.toUpperCase() +'>';
                         }, ' ');
                         


### PR DESCRIPTION
If a string contains XML it would not get displayed.

This escapes any relevant characters so that it can get displayed.
